### PR TITLE
添加TypeScript声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | cb  | func     | null    | 回调接口, cb(bool),  bool 为 true 为 mobile  |
 | query | string | `only screen and (max-width: 767.99px)` | css 的场景判断 |
 
-### unenquireScrenn(handler, query);
+### unenquireScreen(handler, query);
 
 | name       |type            |default  |description     |
 |------------|----------------|---------|----------------|

--- a/main.d.ts
+++ b/main.d.ts
@@ -1,0 +1,35 @@
+import enquire from 'enquire.js';
+
+// copied from @types/enquire.js
+interface Options {
+    /**
+     * If set to true, defers execution of the setup function until the first time the media query is matched
+     */
+    deferSetup?: boolean;
+    /**
+     * If supplied, triggered when a media query matches.
+     */
+    match?(): void;
+    /**
+     * If supplied, triggered when the media query transitions from a matched state to an unmatched state.
+     */
+    unmatch?(): void;
+    /**
+     * If supplied, triggered once, when the handler is registered.
+     */
+    setup?(): void;
+
+    /**
+     * If supplied, triggered when handler is unregistered. Place cleanup code here
+     */
+    destroy?(): void;
+}
+
+type Callback = (flag?: boolean) => void;
+
+const enquireJs = enquire;
+
+export function enquireScreen(cb: Callback, query?: string): Options;
+export function unenquireScreen(handler: Options, query?: string): void;
+
+export default enquireJs;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "enquire.js": "^2.1.6"
   },
   "devDependencies": {
+    "@types/enquire.js": "^2.1.2",
     "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.6.0"
   }


### PR DESCRIPTION
在本地override通过可用 源文件如下：

```typescript
/// <reference types="node" />

declare module 'enquire-js' {
  import enquire from 'enquire.js';

  // copied from @types/enquire.js
  interface Options {
      /**
       * If set to true, defers execution of the setup function until the first time the media query is matched
       */
      deferSetup?: boolean;
      /**
       * If supplied, triggered when a media query matches.
       */
      match?(): void;
      /**
       * If supplied, triggered when the media query transitions from a matched state to an unmatched state.
       */
      unmatch?(): void;
      /**
       * If supplied, triggered once, when the handler is registered.
       */
      setup?(): void;

      /**
       * If supplied, triggered when handler is unregistered. Place cleanup code here
       */
      destroy?(): void;
  }

  type Callback = (flag?: boolean) => void;

  const enquireJs = enquire;

  export function enquireScreen(cb: Callback, query?: string): Options;
  export function unenquireScreen(handler: Options, query?: string): void;

  export default enquireJs;
}
```